### PR TITLE
build: add jraph to pyproject ignore-missing-imports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,7 @@ module = [
     "pkg_resources.*",
     "PIL.*",
     "distrax.*",
+    "jraph.*",
 ]
 ignore_missing_imports = true
 


### PR DESCRIPTION
ignore missing imports for jraph