### PR TITLE
feat: add compute_makespan and test

### DIFF
--- a/jumanji/environments/packing/job_shop/improvement/compute_makespan.py
+++ b/jumanji/environments/packing/job_shop/improvement/compute_makespan.py
@@ -51,7 +51,8 @@ def update_node_fn(
         Array of updated nodes with shape (num_nodes, 3)
     """
 
-    # Each node has a feature (duration, start_time, completion) that updates accross message passing:
+    # Each node has a feature (duration, start_time, completion) that updates accross
+    # message passing:
     # duration the processing time (float)
     # start_time the current start time of the operation (float)
     # completion the current completion status (0 when completed, 1 when not completed)
@@ -72,9 +73,9 @@ def compute_earliest_start_times_and_makespan(
 ) -> Tuple[chex.Array, jnp.float32]:
     """Compute earliest start times and makespan using jraph message passing with max pooling.
        It is an adaptation for GPU of the traditional CPM (Critical Path Method) which computes the
-       starting times of the operations recursively.
-       When starting, the source node is the only one to be scheduled, and message passing propagates
-       the start times recursively to the target node, which in the end contains the makespan.
+       starting times of the operations recursively.When starting, the source node is the only one
+       to be scheduled, and message passing propagates the start times recursively to the target
+       node, which in the end contains the makespan.
        First part of the algorithm in Section 4.4 of the paper (https://arxiv.org/abs/2211.10936).
 
 
@@ -204,9 +205,8 @@ def compute_latest_start_times(
 ) -> chex.Array:
     """Compute latest start times using message passing with max pooling.
        It is the same method as the forward pass but with reversed edges and propagation from target
-       to source, to obtain the latest start times.
-       The latest start times of operations are the latest possible starting times for every operation
-       such that the makespan is not exceeded.
+       to source, to obtain the latest start times. The latest start times of operations are the
+       latest possible starting times for every operation such that the makespan is not exceeded.
        Second part of the algorithm in Section 4.4 of the paper (https://arxiv.org/abs/2211.10936).
 
     Args:

--- a/jumanji/environments/packing/job_shop/improvement/compute_makespan.py
+++ b/jumanji/environments/packing/job_shop/improvement/compute_makespan.py
@@ -1,0 +1,303 @@
+# Copyright 2022 InstaDeep Ltd. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# -----------------------------------------------------------------------------
+# This implementation is inspired by the paper:
+# "Deep Reinforcement Learning Guided Improvement Heuristic for Job Shop Scheduling"
+# by Cong Zhang, Zhiguang Cao, Wen Song, Yaoxin Wu, Jie Zhang
+# (https://arxiv.org/abs/2211.10936).
+#
+# The logic implemented here corresponds to the mechanism described in
+# Section 4.4: "Message Passing for Calculating Schedule".
+# Based on the adjacency matrix of the disjunctive graph, it allows to compute
+# earliest, latest start times and makespan for a given schedule.
+# For clarity, the notations used are the ones of the paper.
+# -----------------------------------------------------------------------------
+
+from typing import Tuple
+
+import chex
+import jax
+import jax.numpy as jnp
+import jraph
+
+
+def update_node_fn(
+    nodes: chex.Array,
+    _sent_attributes: chex.Array,
+    received_attributes: chex.Array,
+    _globals: chex.Array,
+) -> chex.Array:
+    """Update the date and completion status of a node based on the received attributes.
+
+    Args:
+        nodes: Array of nodes with shape (num_nodes, 3)
+        _sent_attributes: Array of sent attributes with shape (num_edges, 2)
+        received_attributes: Array of received attributes with shape (num_edges, 2)
+        _globals: Array of globals with shape (num_globals, 1)
+    Returns:
+        Array of updated nodes with shape (num_nodes, 3)
+    """
+
+    # Each node has a feature (p, d, c) with p the processing time,
+    # d the date and c the completion status
+    node_p = nodes[:, 0]  # remains unchanged
+
+    # Update date and completion status if neighbours
+    received_d = received_attributes[:, 0]
+    received_c = received_attributes[:, 1]
+
+    return jnp.stack([node_p, received_d, received_c], axis=-1)
+
+
+def forward_pass_jraph(
+    adj_mat: chex.Array, ops_durations: chex.Array, max_num_edges: jnp.int32
+) -> Tuple[chex.Array, jnp.float32]:
+    """Compute earliest start times and makespan using jraph message passing with max pooling.
+        First part of the algorithm in Section 4.4 of the paper.
+
+    Args:
+        adj_mat: Adjacency matrix of the disjunctive graph
+                 shape (max_num_jobs x max_num_ops + 2, max_num_jobs x max_num_ops + 2)
+        ops_durations: Processing times of the operations (max_num_jobs, max_num_ops)
+        max_num_edges: Maximum number of edges in the graph.
+
+    Returns:
+        Array of earliest start times for each node and total makespan.
+        Earliest start times correspond, for each operation, to start the earliest possible
+        (as soon as the machine is available).
+    """
+
+    num_nodes = adj_mat.shape[0]
+
+    # Convert ops_durations to a vector of size num_nodes
+    ops_durations = ops_durations.reshape(-1)
+    # Add sink and target nodes with duration of 0
+    ops_durations = jnp.concatenate([jnp.array([0.0]), ops_durations, jnp.array([0.0])])
+
+    # Create node features: (processing time, date, completion status)
+    node_features = jnp.zeros((num_nodes, 3))
+    # Initialize features as in the paper
+    node_features = node_features.at[:, 2].set(jnp.ones(num_nodes))
+    node_features = node_features.at[0].set(jnp.array([0.0, 0.0, 0.0]))  # Source node
+    node_features = node_features.at[:, 0].set(ops_durations)  # Add processing times
+
+    # Create edge features
+    edge_features = jnp.zeros((max_num_edges, 2))  # dummy initialization
+    senders, receivers = jnp.nonzero(adj_mat > 0, size=max_num_edges, fill_value=0)
+
+    # Create graph
+    graph = jraph.GraphsTuple(
+        nodes=node_features,
+        edges=edge_features,
+        senders=senders,
+        receivers=receivers,
+        n_node=jnp.array([num_nodes]),
+        n_edge=jnp.array([len(senders)]),
+        globals=None,
+    )
+
+    def update_edge_fn(
+        _edges: chex.Array,
+        sender_features: chex.Array,
+        _receiver_features: chex.Array,
+        _globals: chex.Array,
+    ) -> chex.Array:
+        """Update the edge features based on the sender and receiver features.
+
+        Args:
+            _edges: Array of edge features with shape (num_edges, 2). Not used.
+            sender_features: Array of sender features with shape (num_edges, 3)
+            _receiver_features: Array of receiver features with shape (num_edges, 3). Not used.
+            _globals: Array of globals with shape (num_globals, 1). Not used.
+
+        Returns:
+            Array of updated edge features with shape (num_edges, 2)
+        """
+
+        sender_p = sender_features[:, 0]
+        sender_d = sender_features[:, 1]
+        sender_c = sender_features[:, 2]
+
+        new_d = sender_p + (1.0 - sender_c) * sender_d
+        new_c = sender_c
+
+        return jnp.stack([new_d, new_c], axis=-1)
+
+    # Create message passing layer
+    net = jraph.GraphNetwork(
+        update_node_fn=update_node_fn,
+        update_edge_fn=update_edge_fn,
+        aggregate_edges_for_nodes_fn=jraph.segment_max,
+        aggregate_nodes_for_globals_fn=None,
+        aggregate_edges_for_globals_fn=None,
+    )
+
+    def check_completion(graph: jraph.GraphsTuple) -> jnp.bool_:
+        """Check if the target node is completed.
+           Used as a stopping condition in the while loop.
+
+        Args:
+            graph: Current graph state.
+
+        Returns:
+            True if the target node is completed, False otherwise.
+        """
+        return graph.nodes[-1, 2] == 1
+
+    def update_graph(graph: jraph.GraphsTuple) -> jraph.GraphsTuple:
+        """Update the graph using the message passing layer.
+
+        Args:
+            graph: Current graph state.
+
+        Returns:
+            Updated graph state.
+        """
+        output_graph = net(graph)
+        # Keep source node to (0, 0, 0)
+        output_graph = output_graph._replace(
+            nodes=output_graph.nodes.at[0].set(jnp.array([0.0, 0.0, 0.0]))
+        )
+        return output_graph
+
+    # Run the message passing loop until the target node is completed
+    output_graph = jax.lax.while_loop(check_completion, update_graph, graph)
+
+    # Return earliest start times and makespan
+    return output_graph.nodes[:, 1], output_graph.nodes[-1, 1]
+
+
+def backward_pass_jraph(
+    adj_mat: chex.Array, ops_durations: chex.Array, makespan: jnp.float32, max_num_edges: jnp.int32
+) -> chex.Array:
+    """Compute latest start times using message passing with max pooling.
+        Second part of the algorithm in Section 4.4 of the paper.
+
+    Args:
+        adj_mat: Adjacency matrix of the disjunctive graph
+                 shape (max_num_jobs x max_num_ops + 2, max_num_jobs x max_num_ops + 2)
+        ops_durations: Processing times of the operations (max_num_jobs, max_num_ops)
+    Returns:
+        Array of latest start times for each node.
+        Latest start times correspond, for each operation, to start the latest possible
+        so that it does not exceed the makespan.
+    """
+    num_nodes = adj_mat.shape[0]
+
+    # convert ops_durations to a vector of size num_nodes
+    ops_durations = ops_durations.reshape(-1)
+    # add sink and target nodes with duration of 0
+    ops_durations = jnp.concatenate([jnp.array([0.0]), ops_durations, jnp.array([0.0])])
+
+    # Create node features: (processing time, date, completion status)
+    node_features = jnp.ones((num_nodes, 3))
+    node_features = node_features.at[:, 1].set(-jnp.ones(num_nodes))
+    node_features = node_features.at[-1].set(jnp.array([0.0, -makespan, 0.0]))  # Source node
+    node_features = node_features.at[:, 0].set(ops_durations)  # add processing times
+
+    # Create edge features: edge weights
+    # Transposed matrix to get reversed edges
+    senders, receivers = jnp.nonzero(adj_mat.T > 0, size=max_num_edges, fill_value=num_nodes - 1)
+
+    edge_features = jnp.zeros((max_num_edges, 2))  # dummy initialization
+
+    graph = jraph.GraphsTuple(
+        nodes=node_features,
+        edges=edge_features,
+        senders=senders,
+        receivers=receivers,
+        n_node=jnp.array([num_nodes]),
+        n_edge=jnp.array([len(senders)]),
+        globals=None,
+    )
+    jax.debug.print("graph created")
+
+    def update_edge_fn(
+        _edges: chex.Array,
+        sender_features: chex.Array,
+        _receiver_features: chex.Array,
+        _globals: chex.Array,
+    ) -> chex.Array:
+        # sender_features: [num_edges, 3]  with (p, d, c)
+
+        sender_p = _receiver_features[:, 0]
+        sender_d = sender_features[:, 1]
+        sender_c = sender_features[:, 2]
+
+        new_d = sender_p + (1.0 - sender_c) * sender_d
+        new_c = sender_c
+
+        return jnp.stack([new_d, new_c], axis=-1)
+
+    net = jraph.GraphNetwork(
+        update_node_fn=update_node_fn,
+        update_edge_fn=update_edge_fn,
+        aggregate_edges_for_nodes_fn=jraph.segment_max,
+        aggregate_nodes_for_globals_fn=None,
+        aggregate_edges_for_globals_fn=None,
+    )
+
+    def check_completion(graph: jraph.GraphsTuple) -> jnp.bool_:
+        """Check if the source node is completed.
+           Used as a stopping condition in the while loop.
+
+        Args:
+            graph: Current graph state.
+
+        Returns:
+            True if the source node is completed, False otherwise.
+        """
+        return graph.nodes[0, 2] == 1
+
+    def update_graph(graph: jraph.GraphsTuple) -> jraph.GraphsTuple:
+        """Update the graph using the message passing layer.
+
+        Args:
+            graph: Current graph state.
+
+        Returns:
+            Updated graph state.
+        """
+        output_graph = net(graph)
+        output_graph = output_graph._replace(
+            nodes=output_graph.nodes.at[-1].set(jnp.array([0.0, -makespan, 0.0]))
+        )  # keep source node to (0, 0)
+        return output_graph
+
+    # Run the message passing loop until the source node is completed
+    output_graph = jax.lax.while_loop(check_completion, update_graph, graph)
+
+    # Return latest start times
+    return -output_graph.nodes[:, 1]
+
+
+def forward_backward_pass_jraph(
+    adj_mat: chex.Array, ops_durations: chex.Array, max_num_edges: jnp.int32
+) -> Tuple[chex.Array, chex.Array, jnp.float32]:
+    """Compute earliest, latest start times and makespan.
+
+    Args:
+        adj_mat: Adjacency matrix of the disjunctive graph
+                 shape (max_num_jobs x max_num_ops + 2, max_num_jobs x max_num_ops + 2)
+        ops_durations: Processing times of the operations (max_num_jobs, max_num_ops)
+    Returns:
+        est: earliest start times (max_num_jobs x max_num_ops,)
+        lst: latest start times (max_num_jobs x max_num_ops,)
+        makespan: makespan of the schedule (float)
+    """
+
+    est, makespan = forward_pass_jraph(adj_mat, ops_durations, max_num_edges)
+    lst = backward_pass_jraph(adj_mat, ops_durations, makespan, max_num_edges)
+    return est, lst, makespan

--- a/jumanji/environments/packing/job_shop/improvement/compute_makespan_test.py
+++ b/jumanji/environments/packing/job_shop/improvement/compute_makespan_test.py
@@ -30,7 +30,8 @@ MAX_NUM_EDGES = 50
 
 
 class TestComputeMakespanJraph:
-    """Test suite for the compute_earliest_start_times_and_makespan, and compute_latest_start_times functions."""
+    """Test suite for the compute_earliest_start_times_and_makespan,
+    compute_latest_start_times and compute_est_lst_makespan functions."""
 
     @pytest.fixture
     def matrices_example(self) -> Tuple[chex.Array, chex.Array, chex.Array]:
@@ -275,7 +276,6 @@ class TestComputeMakespanJraph:
 
         expected_est = jnp.array([0.0, 0.0, 2.0, 5.0, 6.0])
         expected_lst = jnp.array([0.0, 0.0, 2.0, 5.0, 6.0])
-        expected_makespan = 6
 
         assert jnp.allclose(est, expected_est)
         assert jnp.allclose(lst, expected_lst)

--- a/jumanji/environments/packing/job_shop/improvement/compute_makespan_test.py
+++ b/jumanji/environments/packing/job_shop/improvement/compute_makespan_test.py
@@ -1,0 +1,201 @@
+# Copyright 2022 InstaDeep Ltd. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Tuple
+
+import chex
+import jax
+import jax.numpy as jnp
+import pytest
+
+from jumanji.environments.packing.job_shop.improvement.compute_makespan import (
+    backward_pass_jraph,
+    forward_pass_jraph,
+)
+
+# Hardcoded max number of edges for the example matrices
+MAX_NUM_EDGES = 50
+
+
+class TestForwardPassJraph:
+    """Test suite for the forward_pass_jraph function."""
+
+    @pytest.fixture
+    def matrices_example(self) -> Tuple[chex.Array, chex.Array, chex.Array]:
+        """
+        Example matrices for the forward and backward pass.
+        There are 8 valid operations, from 0 to 7. Machines are given by ops_machines_ids.
+        adj_mat_mc corresponds to the following operation order on machines:
+        - Machine 0: 0 -> 3
+        - Machine 1: 1 -> 6 -> 5
+        - Machine 2: 4 -> 2 -> 7
+        """
+
+        # For indication
+        ops_machine_ids = jnp.array(
+            [
+                [0, 1, 2],
+                [0, 2, 1],
+                [1, 2, -1],
+            ],
+            jnp.int32,
+        )
+        del ops_machine_ids
+
+        ops_durations = jnp.array(
+            [
+                [3, 2, 2],
+                [2, 1, 4],
+                [4, 3, -1],
+            ],
+            jnp.int32,
+        )
+
+        adj_mat_pc = jnp.array(
+            [
+                [0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 0],
+                [0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0],
+                [0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2],
+                [0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4],
+                [0, 0, 0, 0, 0, 0, 0, 0, 4, 0, 0],
+                [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3],
+                [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            ]
+        )
+        # Machine constraint matrix
+        adj_mat_mc = jnp.array(
+            [
+                [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0],
+                [0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0],
+                [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                [0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            ]
+        )
+        return ops_durations, adj_mat_pc, adj_mat_mc
+
+    def test_forward_pass_jraph__env_test_example(
+        self, matrices_example: Tuple[chex.Array, chex.Array, chex.Array]
+    ) -> None:
+        """Test of forward pass using the example matrices."""
+
+        ops_durations, adj_mat_pc, adj_mat_mc = matrices_example
+
+        # Combine matrices to obtain the adjacency matrix of the disjunctive graph
+        adj_mat = jnp.maximum(adj_mat_pc, adj_mat_mc)
+
+        est, makespan = forward_pass_jraph(adj_mat, ops_durations, MAX_NUM_EDGES)
+
+        # Verify source node has earliest start time = 0
+        assert est[0] == 0
+
+        # Verify target node has correct makespan, equal to 13.
+        assert makespan == 13
+
+    def test_forward_pass_jraph__simple_chain(self) -> None:
+        """Test forward pass on a simple chain graph, with one job and 3 operations."""
+        # Create a simple chain graph: 0 -> 1 -> 2 -> 3
+        adj_mat = jnp.array(
+            [[0, 1, 0, 0, 0], [0, 0, 2, 0, 0], [0, 0, 0, 3, 0], [0, 0, 0, 0, 1], [0, 0, 0, 0, 0]]
+        )  # one job, one machine
+
+        ops_durations = jnp.array([2.0, 3.0, 1.0])
+
+        est, makespan = forward_pass_jraph(adj_mat, ops_durations, MAX_NUM_EDGES)
+
+        # Expected earliest start times:
+        # Node 0 (source): 0
+        # Node 1: 0
+        # Node 2: 2
+        # Node 3: 5
+        # Node 4 (target): 6
+
+        expected_est = jnp.array([0.0, 0.0, 2.0, 5.0, 6.0])
+        assert jnp.allclose(est, expected_est)
+        assert makespan == 6
+
+    def test_forward_pass_jraph__jit(
+        self, matrices_example: Tuple[chex.Array, chex.Array, chex.Array]
+    ) -> None:
+        """Confirm that the forward pass is only compiled once when jitted."""
+
+        ops_durations, adj_mat_pc, adj_mat_mc = matrices_example
+        # Combine matrices and set processing times
+        adj_mat = jnp.maximum(adj_mat_pc, adj_mat_mc)
+
+        # JIT the function
+        jitted_fn = jax.jit(forward_pass_jraph, static_argnums=(2,))
+
+        # First call (compilation)
+        est1, makespan1 = jitted_fn(adj_mat, ops_durations, MAX_NUM_EDGES)
+
+        # Second call (should use cached compilation)
+        est2, makespan2 = jitted_fn(adj_mat, ops_durations, MAX_NUM_EDGES)
+
+        assert jnp.allclose(est1, est2)
+        assert makespan1 == makespan2
+        assert makespan1 == 13
+
+    def test_backward_pass_jraph__env_test_example(
+        self, matrices_example: Tuple[chex.Array, chex.Array, chex.Array]
+    ) -> None:
+        """Test forward pass using the same example as in conftest DummyGenerator."""
+
+        ops_durations, adj_mat_pc, adj_mat_mc = matrices_example
+
+        # Combine matrices and set processing times
+        adj_mat = jnp.maximum(adj_mat_pc, adj_mat_mc)
+
+        makespan = 13
+        lst = backward_pass_jraph(adj_mat, ops_durations, makespan, MAX_NUM_EDGES)
+
+        # Verify source node has lst = 0 and last node has lst = makespan
+        assert lst[0] == 0
+        assert lst[-1] == 13
+
+        # Verify each operation has correct latest start time
+        assert jnp.all(lst[1:9] == jnp.array([0, 3, 8, 5, 7, 9, 5, 10]))
+
+    def test_jit_backward_pass_jraph(
+        self, matrices_example: Tuple[chex.Array, chex.Array, chex.Array]
+    ) -> None:
+        """Test that backward pass can be jitted."""
+
+        ops_durations, adj_mat_pc, adj_mat_mc = matrices_example
+
+        # Combine matrices
+        adj_mat = jnp.maximum(adj_mat_pc, adj_mat_mc)
+
+        makespan = 13
+
+        # Test that backward pass can be jitted
+        lst = jax.jit(backward_pass_jraph, static_argnums=(3,))(
+            adj_mat, ops_durations, makespan, MAX_NUM_EDGES
+        )
+
+        # Verify sink node has lst = makespan
+        assert lst[-1] == makespan
+
+        # Verify source node has lst >= 0
+        assert lst[0] >= 0

--- a/jumanji/environments/packing/job_shop/improvement/compute_makespan_test.py
+++ b/jumanji/environments/packing/job_shop/improvement/compute_makespan_test.py
@@ -20,16 +20,17 @@ import jax.numpy as jnp
 import pytest
 
 from jumanji.environments.packing.job_shop.improvement.compute_makespan import (
-    backward_pass_jraph,
-    forward_pass_jraph,
+    compute_earliest_start_times_and_makespan,
+    compute_est_lst_makespan,
+    compute_latest_start_times,
 )
 
 # Hardcoded max number of edges for the example matrices
 MAX_NUM_EDGES = 50
 
 
-class TestForwardPassJraph:
-    """Test suite for the forward_pass_jraph function."""
+class TestComputeMakespanJraph:
+    """Test suite for the compute_earliest_start_times_and_makespan, and compute_latest_start_times functions."""
 
     @pytest.fixture
     def matrices_example(self) -> Tuple[chex.Array, chex.Array, chex.Array]:
@@ -95,7 +96,7 @@ class TestForwardPassJraph:
         )
         return ops_durations, adj_mat_pc, adj_mat_mc
 
-    def test_forward_pass_jraph__env_test_example(
+    def test_compute_earliest_start_times_and_makespan__env_test_example(
         self, matrices_example: Tuple[chex.Array, chex.Array, chex.Array]
     ) -> None:
         """Test of forward pass using the example matrices."""
@@ -105,7 +106,9 @@ class TestForwardPassJraph:
         # Combine matrices to obtain the adjacency matrix of the disjunctive graph
         adj_mat = jnp.maximum(adj_mat_pc, adj_mat_mc)
 
-        est, makespan = forward_pass_jraph(adj_mat, ops_durations, MAX_NUM_EDGES)
+        est, makespan = compute_earliest_start_times_and_makespan(
+            adj_mat, ops_durations, MAX_NUM_EDGES
+        )
 
         # Verify source node has earliest start time = 0
         assert est[0] == 0
@@ -113,7 +116,7 @@ class TestForwardPassJraph:
         # Verify target node has correct makespan, equal to 13.
         assert makespan == 13
 
-    def test_forward_pass_jraph__simple_chain(self) -> None:
+    def test_compute_earliest_start_times_and_makespan__simple_chain(self) -> None:
         """Test forward pass on a simple chain graph, with one job and 3 operations."""
         # Create a simple chain graph: 0 -> 1 -> 2 -> 3
         adj_mat = jnp.array(
@@ -122,7 +125,9 @@ class TestForwardPassJraph:
 
         ops_durations = jnp.array([2.0, 3.0, 1.0])
 
-        est, makespan = forward_pass_jraph(adj_mat, ops_durations, MAX_NUM_EDGES)
+        est, makespan = compute_earliest_start_times_and_makespan(
+            adj_mat, ops_durations, MAX_NUM_EDGES
+        )
 
         # Expected earliest start times:
         # Node 0 (source): 0
@@ -135,7 +140,7 @@ class TestForwardPassJraph:
         assert jnp.allclose(est, expected_est)
         assert makespan == 6
 
-    def test_forward_pass_jraph__jit(
+    def test_compute_earliest_start_times_and_makespan__jit(
         self, matrices_example: Tuple[chex.Array, chex.Array, chex.Array]
     ) -> None:
         """Confirm that the forward pass is only compiled once when jitted."""
@@ -145,7 +150,10 @@ class TestForwardPassJraph:
         adj_mat = jnp.maximum(adj_mat_pc, adj_mat_mc)
 
         # JIT the function
-        jitted_fn = jax.jit(forward_pass_jraph, static_argnums=(2,))
+        jitted_fn = jax.jit(
+            chex.assert_max_traces(compute_earliest_start_times_and_makespan, n=1),
+            static_argnums=(2,),
+        )
 
         # First call (compilation)
         est1, makespan1 = jitted_fn(adj_mat, ops_durations, MAX_NUM_EDGES)
@@ -157,7 +165,7 @@ class TestForwardPassJraph:
         assert makespan1 == makespan2
         assert makespan1 == 13
 
-    def test_backward_pass_jraph__env_test_example(
+    def test_compute_latest_start_times__env_test_example(
         self, matrices_example: Tuple[chex.Array, chex.Array, chex.Array]
     ) -> None:
         """Test forward pass using the same example as in conftest DummyGenerator."""
@@ -168,7 +176,7 @@ class TestForwardPassJraph:
         adj_mat = jnp.maximum(adj_mat_pc, adj_mat_mc)
 
         makespan = 13
-        lst = backward_pass_jraph(adj_mat, ops_durations, makespan, MAX_NUM_EDGES)
+        lst = compute_latest_start_times(adj_mat, ops_durations, makespan, MAX_NUM_EDGES)
 
         # Verify source node has lst = 0 and last node has lst = makespan
         assert lst[0] == 0
@@ -177,10 +185,32 @@ class TestForwardPassJraph:
         # Verify each operation has correct latest start time
         assert jnp.all(lst[1:9] == jnp.array([0, 3, 8, 5, 7, 9, 5, 10]))
 
-    def test_jit_backward_pass_jraph(
+    def test_compute_latest_start_times__simple_chain(self) -> None:
+        """Test backward pass on a simple chain graph, with one job and 3 operations."""
+        # Create a simple chain graph: 0 -> 1 -> 2 -> 3
+        adj_mat = jnp.array(
+            [[0, 1, 0, 0, 0], [0, 0, 2, 0, 0], [0, 0, 0, 3, 0], [0, 0, 0, 0, 1], [0, 0, 0, 0, 0]]
+        )  # one job, one machine
+
+        ops_durations = jnp.array([2.0, 3.0, 1.0])
+
+        makespan = 6
+        lst = compute_latest_start_times(adj_mat, ops_durations, makespan, MAX_NUM_EDGES)
+
+        # Expected latest start times:
+        # Node 0 (source): 0
+        # Node 1: 0
+        # Node 2: 2
+        # Node 3: 5
+        # Node 4 (target): 6
+
+        expected_lst = jnp.array([0.0, 0.0, 2.0, 5.0, 6.0])
+        assert jnp.allclose(lst, expected_lst)
+
+    def test_compute_latest_start_times__jit(
         self, matrices_example: Tuple[chex.Array, chex.Array, chex.Array]
     ) -> None:
-        """Test that backward pass can be jitted."""
+        """Test that backward pass can be jitted and only compiled once."""
 
         ops_durations, adj_mat_pc, adj_mat_mc = matrices_example
 
@@ -189,13 +219,87 @@ class TestForwardPassJraph:
 
         makespan = 13
 
-        # Test that backward pass can be jitted
-        lst = jax.jit(backward_pass_jraph, static_argnums=(3,))(
-            adj_mat, ops_durations, makespan, MAX_NUM_EDGES
+        jitted_fn = jax.jit(
+            chex.assert_max_traces(compute_latest_start_times, n=1), static_argnums=(3,)
         )
 
+        # First call (compilation)
+        lst1 = jitted_fn(adj_mat, ops_durations, makespan, MAX_NUM_EDGES)
+
+        # Second call (should use cached compilation)
+        lst2 = jitted_fn(adj_mat, ops_durations, makespan, MAX_NUM_EDGES)
+
+        assert jnp.allclose(lst1, lst2)
+
         # Verify sink node has lst = makespan
-        assert lst[-1] == makespan
+        assert lst1[-1] == makespan
 
         # Verify source node has lst >= 0
-        assert lst[0] >= 0
+        assert lst1[0] >= 0
+
+    def test_compute_est_lst_makespan__env_test_example(
+        self, matrices_example: Tuple[chex.Array, chex.Array, chex.Array]
+    ) -> None:
+        """Test forward and backward pass using the example matrices."""
+
+        ops_durations, adj_mat_pc, adj_mat_mc = matrices_example
+
+        # Combine matrices
+        adj_mat = jnp.maximum(adj_mat_pc, adj_mat_mc)
+
+        est, lst, makespan = compute_est_lst_makespan(adj_mat, ops_durations, MAX_NUM_EDGES)
+
+        # Verify source node has est = 0
+        assert est[0] == 0
+
+        # Verify target node has makespan = 13
+        assert makespan == 13
+
+    def test_compute_est_lst_makespan__simple_chain(self) -> None:
+        """Test forward and backward pass on a simple chain graph, with one job and 3 operations."""
+        # Create a simple chain graph: 0 -> 1 -> 2 -> 3
+        adj_mat = jnp.array(
+            [[0, 1, 0, 0, 0], [0, 0, 2, 0, 0], [0, 0, 0, 3, 0], [0, 0, 0, 0, 1], [0, 0, 0, 0, 0]]
+        )  # one job, one machine
+
+        ops_durations = jnp.array([2.0, 3.0, 1.0])
+
+        est, lst, makespan = compute_est_lst_makespan(adj_mat, ops_durations, MAX_NUM_EDGES)
+
+        # Expected earliest start times:
+        # Node 0 (source): 0
+        # Node 1: 0
+        # Node 2: 2
+        # Node 3: 5
+        # Node 4 (target): 6
+
+        expected_est = jnp.array([0.0, 0.0, 2.0, 5.0, 6.0])
+        expected_lst = jnp.array([0.0, 0.0, 2.0, 5.0, 6.0])
+        expected_makespan = 6
+
+        assert jnp.allclose(est, expected_est)
+        assert jnp.allclose(lst, expected_lst)
+
+    def test_compute_est_lst_makespan__jit(
+        self, matrices_example: Tuple[chex.Array, chex.Array, chex.Array]
+    ) -> None:
+        """Test that forward and backward pass can be jitted and only compiled once."""
+
+        ops_durations, adj_mat_pc, adj_mat_mc = matrices_example
+
+        # Combine matrices
+        adj_mat = jnp.maximum(adj_mat_pc, adj_mat_mc)
+
+        jitted_fn = jax.jit(
+            chex.assert_max_traces(compute_est_lst_makespan, n=1), static_argnums=(2,)
+        )
+
+        # First call (compilation)
+        est1, lst1, makespan1 = jitted_fn(adj_mat, ops_durations, MAX_NUM_EDGES)
+
+        # Second call (should use cached compilation)
+        est2, lst2, makespan2 = jitted_fn(adj_mat, ops_durations, MAX_NUM_EDGES)
+
+        assert jnp.allclose(est1, est2)
+        assert jnp.allclose(lst1, lst2)
+        assert makespan1 == makespan2


### PR DESCRIPTION
Given the adjacency matrix of the graph (machine constraints + precedence constraints), computes the makespan of the schedule, which is used for the reward. It also computes, for each operation, the earliest and latest starting times. This allows to identify operations located on the critical path.