### PR TITLE
Small fix for compute_makespan.py features

### DIFF
--- a/jumanji/environments/packing/job_shop/improvement/compute_makespan.py
+++ b/jumanji/environments/packing/job_shop/improvement/compute_makespan.py
@@ -165,36 +165,25 @@ def compute_earliest_start_times_and_makespan(
         aggregate_edges_for_globals_fn=None,
     )
 
-    def check_completion(graph: jraph.GraphsTuple) -> jnp.bool_:
-        """Check if the target node is completed.
-           Used as a stopping condition in the while loop.
+    def check_completion(state: Tuple[jraph.GraphsTuple, jnp.int32]) -> jnp.bool_:
+        graph, iteration_count = state
+        target_not_completed = graph.nodes[-1, 2] == 1
+        reached_iteration_limit = iteration_count >= num_nodes
+        return jnp.logical_and(target_not_completed, ~reached_iteration_limit)
 
-        Args:
-            graph: Current graph state.
-
-        Returns:
-            True if the target node is completed, False otherwise.
-        """
-        return graph.nodes[-1, 2] == 1
-
-    def update_graph(graph: jraph.GraphsTuple) -> jraph.GraphsTuple:
-        """Update the graph using the message passing layer.
-
-        Args:
-            graph: Current graph state.
-
-        Returns:
-            Updated graph state.
-        """
+    def update_graph(
+        state: Tuple[jraph.GraphsTuple, jnp.int32],
+    ) -> Tuple[jraph.GraphsTuple, jnp.int32]:
+        graph, iteration_count = state
         output_graph = net(graph)
-        # Keep source node to (0, 0, 0)
         output_graph = output_graph._replace(
             nodes=output_graph.nodes.at[0].set(jnp.array([0.0, 0.0, 0.0]))
         )
-        return output_graph
+        return output_graph, iteration_count + 1
 
     # Run the message passing loop until the target node is completed
-    output_graph = jax.lax.while_loop(check_completion, update_graph, graph)
+    # output_graph = jax.lax.while_loop(check_completion, update_graph, graph)
+    output_graph, _ = jax.lax.while_loop(check_completion, update_graph, (graph, 0))
 
     # Return earliest start times and makespan
     return output_graph.nodes[:, 1], output_graph.nodes[-1, 1]
@@ -293,36 +282,25 @@ def compute_latest_start_times(
         aggregate_edges_for_globals_fn=None,
     )
 
-    def check_completion(graph: jraph.GraphsTuple) -> jnp.bool_:
-        """Check if the source node is completed.
-           Used as a stopping condition in the while loop.
+    def check_completion(state: Tuple[jraph.GraphsTuple, jnp.int32]) -> jnp.bool_:
+        graph, iteration_count = state
+        source_not_completed = graph.nodes[0, 2] == 1
+        reached_iteration_limit = iteration_count >= num_nodes
+        return jnp.logical_and(source_not_completed, ~reached_iteration_limit)
 
-        Args:
-            graph: Current graph state.
-
-        Returns:
-            True if the source node is completed, False otherwise.
-        """
-        return graph.nodes[0, 2] == 1
-
-    def update_graph(graph: jraph.GraphsTuple) -> jraph.GraphsTuple:
-        """Update the graph using the message passing layer.
-
-        Args:
-            graph: Current graph state.
-
-        Returns:
-            Updated graph state.
-        """
+    def update_graph(
+        state: Tuple[jraph.GraphsTuple, jnp.int32],
+    ) -> Tuple[jraph.GraphsTuple, jnp.int32]:
+        graph, iteration_count = state
         output_graph = net(graph)
-        # Keep target node to (0, -makespan, 0)
         output_graph = output_graph._replace(
             nodes=output_graph.nodes.at[-1].set(jnp.array([0.0, -makespan, 0.0]))
         )
-        return output_graph
+        return output_graph, iteration_count + 1
 
-    # Run the message passing loop until the source node is completed
-    output_graph = jax.lax.while_loop(check_completion, update_graph, graph)
+    # Run the message passing loop until the target node is completed
+    # output_graph = jax.lax.while_loop(check_completion, update_graph, graph)
+    output_graph, _ = jax.lax.while_loop(check_completion, update_graph, (graph, 0))
 
     # Return latest start times
     return -output_graph.nodes[:, 1]
@@ -345,4 +323,7 @@ def compute_est_lst_makespan(
 
     est, makespan = compute_earliest_start_times_and_makespan(adj_mat, ops_durations, max_num_edges)
     lst = compute_latest_start_times(adj_mat, ops_durations, makespan, max_num_edges)
+    # Sanitize to -1 for invalid/non-finite values
+    est = jnp.where(jnp.isfinite(est), est, -1)
+    lst = jnp.where(jnp.isfinite(lst), lst, -1)
     return est, lst, makespan

--- a/jumanji/environments/packing/job_shop/improvement/docs/doc.md
+++ b/jumanji/environments/packing/job_shop/improvement/docs/doc.md
@@ -42,6 +42,30 @@
 
 **Target Node**: Virtual ending node in the disjunctive graph connected to all job-ending operations.
 
+## Schedule Evaluation via Message-Passing (Section 4.4 from Zhang et al.)
+
+The computation of earliest start times (EST) and latest start times (LST) for each operation is fundamental to identifying the critical path and evaluating schedule quality. Our implementation in `compute_makespan.py` uses a GPU-compatible message-passing mechanism inspired by Graph Neural Networks, as described in Section 4.4 of the reference paper.
+
+**Reference:** Cong Zhang, Zhiguang Cao, Wen Song, Yaoxin Wu, Jie Zhang. "Deep Reinforcement Learning Guided Improvement Heuristic for Job Shop Scheduling." *arXiv preprint arXiv:2211.10936* (2022). [https://arxiv.org/abs/2211.10936](https://arxiv.org/abs/2211.10936)
+
+### Message-Passing Algorithm
+
+Given a directed disjunctive graph $G$ representing a solution $s$, the algorithm maintains a message $ms_V = (d_V, c_V)$ for each node $V \in O$. The process works as follows:
+
+**Forward Pass (EST Calculation):**
+- Initialize: $d_V = 0$ and $c_V = 1$ for all nodes, except $c_V = 0$ for source node $O_S$
+- Update messages using max-pooling: $$d_V \leftarrow mp_{max}\left(\{p_U + (1 - c_U) \cdot d_U \mid \forall U \in \mathcal{N}(V)\}\right)$$
+- After $H$ iterations: $d_V = est_V$ for all operations, and $d_T = C_{max}(s)$ (makespan)
+
+**Backward Pass (LST Calculation):**
+- Initialize: $d_V = -1$ and $c_V = 1$, except $d_T = -C_{max}(s)$ and $c_T = 0$ for target node $O_T$
+- Update messages in reverse graph: $$d_V = mp_{max}\left(\{p_U + (1 - c_U) \cdot d_U \mid \forall U \in \mathcal{N}(V)\}\right)$$
+- After $H$ iterations: $d_V = -lst_V$ for all operations
+
+This parallel approach enables efficient batch processing on GPU, significantly reducing computation time compared to traditional Critical Path Method (CPM) while maintaining mathematical equivalence.
+
+**Implementation:** See [`compute_makespan.py`](../compute_makespan.py) for the complete JAX implementation of this message-passing evaluator.
+
 ## Critical Block Features computation (via `get_critical_operations_features` in `get_actions.py`)
 
 ### What does this function do?


### PR DESCRIPTION
Before, an infinite loop was theoretically possible if the completion condition was not fulfilled (impossible for valid states), making it harder to debug. We add a maximum number of iterations to prevent it.

We also enforce est and lst arrays to be finite by replacing non finite values by -1 (this prevents smoke issues in tests).

Add of doc in doc.md